### PR TITLE
Adds relevance order to searches by (partial) name

### DIFF
--- a/src/main/java/fayder/restcountries/domain/CountryNameRelevance.java
+++ b/src/main/java/fayder/restcountries/domain/CountryNameRelevance.java
@@ -1,0 +1,83 @@
+package fayder.restcountries.domain;
+
+import java.text.Normalizer;
+
+// Represents the relevance of a country as a search result.
+// The relevance value is calculated according to whether a search term is an 
+// exact, prefix or partial match of the country's name or any of its alternative names.
+public class CountryNameRelevance implements Comparable<CountryNameRelevance> {
+	
+	private int relevance;
+	
+	protected CountryNameRelevance(int relevance) {
+		this.relevance = relevance;
+	}
+	
+	private static final CountryNameRelevance EXACT_MATCH_NAME = new CountryNameRelevance(5000);
+	private static final CountryNameRelevance EXACT_MATCH_ALTSPELLING = new CountryNameRelevance(4000);
+	private static final CountryNameRelevance NO_MATCH = new CountryNameRelevance(0);
+	
+	private static final CountryNameRelevance PARTIAL_MATCH_NAME = new CountryNameRelevance(3000);
+	private static final CountryNameRelevance PARTIAL_MATCH_ALTSPELLING = new CountryNameRelevance(2000);
+	
+	// TODO This method copies the one in CountryServiceBase, need to find a common place to put it.
+	private static String normalize(String string) {
+        return Normalizer.normalize(string, Normalizer.Form.NFD)
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+    }
+
+	public static CountryNameRelevance higher(CountryNameRelevance r1, CountryNameRelevance r2) {
+		if(r1.compareTo(r2) > 0) {
+			return r1;
+		}
+		return r2;
+	}
+
+    public static CountryNameRelevance calculateCountryRelevance(BaseCountry country, String query) {
+		String normCountryName = normalize(country.getName().toLowerCase());
+        CountryNameRelevance relevance = NO_MATCH;
+        
+        if(normCountryName.equals(query)) {
+            relevance = higher(relevance, EXACT_MATCH_NAME);
+            // There is no match more relevant than this.
+            return relevance;
+        }
+        
+        int matchIndex = normCountryName.indexOf(query);
+        if(matchIndex >= 0) {
+        	relevance = higher(relevance, PARTIAL_MATCH_NAME);
+        }
+        
+        for(String alternative : country.getAltSpellings()) {
+        	String normAlternative = normalize(alternative.toLowerCase());
+        	if(normAlternative.equals(query)) {
+            	relevance = higher(relevance, EXACT_MATCH_ALTSPELLING);
+            	// exact match is already better than any partial we can find
+            	break;
+            }
+            
+            matchIndex = normAlternative.indexOf(query);
+            if(matchIndex >= 0) {
+            	relevance = higher(relevance, PARTIAL_MATCH_ALTSPELLING);
+            }
+        }
+		return relevance == NO_MATCH? null : relevance;
+	}
+
+	@Override
+	public int compareTo(CountryNameRelevance o) {
+		return Integer.compare(relevance, o.relevance);
+	}
+	
+	@Override
+	public boolean equals(Object otherObject) {
+		if(this == otherObject) return true;
+		
+		if(otherObject == null) return false;
+		
+		if(getClass() != otherObject.getClass()) return false;
+		
+		CountryNameRelevance other = (CountryNameRelevance)otherObject;
+		return relevance == other.relevance;
+	}
+}

--- a/src/main/java/fayder/restcountries/domain/SortedMultimap.java
+++ b/src/main/java/fayder/restcountries/domain/SortedMultimap.java
@@ -1,0 +1,52 @@
+package fayder.restcountries.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+// Acts like a SortedMap, but allows associating several values to the same key.
+public class SortedMultimap<K extends Comparable<K>,V> {
+	private SortedMap<K, List<V>> map;
+
+	public SortedMultimap() {
+		map = new TreeMap<>();
+	}
+
+	public SortedMultimap(boolean descendingOrder) {
+		if(descendingOrder) {
+			map = new TreeMap<>(new Comparator<K>() {
+				public int compare(K k1, K k2) {
+					return k2.compareTo(k1);
+				}
+			});
+		} else {
+			map = new TreeMap<>();
+		}
+	}
+	
+	public void put(K key, V value) {
+    	if(map.containsKey(key)) {
+    		map.get(key).add(value);
+    	} else {
+    		List<V> list = new ArrayList<>();
+    		list.add(value);
+    		map.put(key, list);
+    	}
+    }
+	
+	public List<V> values() {
+		return flatten(map.values());
+	}
+    
+    private static <V> List<V> flatten(Collection<List<V>> nested) {
+    	List<V> result = new ArrayList<>();
+    	for(List<V> list: nested) {
+    		result.addAll(list);
+    	}
+    	return result;
+    }
+
+}

--- a/src/test/java/fayder/restcountries/v2/CountryServiceTest.java
+++ b/src/test/java/fayder/restcountries/v2/CountryServiceTest.java
@@ -5,6 +5,8 @@ import fayder.restcountries.v2.rest.CountryService;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class CountryServiceTest {
@@ -61,6 +63,47 @@ public class CountryServiceTest {
         Assert.assertFalse(countries.isEmpty());
         Assert.assertEquals("Norway", countries.get(0).getName());
     }
+    
+    @Test
+  	public void getByNameWithRelevance() throws Exception {
+  		System.out.println("Running Test getByNameWithRelevance");
+  		
+  		// No match
+  		String query = "No match";
+  		List<String> expectedNames = new ArrayList<>();
+  		testSubstringSearchByRelevance(query, expectedNames);
+  		
+  		// Exact match in alternative spellings is more relevant than partial match in country name.
+  		query = "UK";
+  		expectedNames = Arrays.asList("United Kingdom of Great Britain and Northern Ireland", "Ukraine", "Cook Islands", 
+  				"Korea (Democratic People's Republic of)");
+  		testSubstringSearchByRelevance(query, expectedNames);
+  		
+  		// Partial match in country name (at any position) is more relevant than partial match in alternative spellings
+  		query = "kin";
+  		expectedNames = Arrays.asList("Burkina Faso", "United Kingdom of Great Britain and Northern Ireland", "Bahrain",
+  				"Belgium", "Bhutan", "Cambodia", "Congo (Democratic Republic of the)", "Denmark", "Jordan", "Lesotho",
+  				"Marshall Islands", "Morocco", "Norway", "Saudi Arabia", "Spain", "Swaziland", "Sweden", "Thailand");
+  		testSubstringSearchByRelevance(query, expectedNames);
+  		
+  		// Another example.
+  		query = "ote";
+  		expectedNames = Arrays.asList("Côte d'Ivoire", "New Zealand");
+  		testSubstringSearchByRelevance(query, expectedNames);
+  	}
+  	
+  	private void testSubstringSearchByRelevance(String query, List<String> result) {
+  		System.out.println("testing \"" + query + "\"");
+  		List<Country> countries = CountryService.getInstance().getByName(query, false);
+  		Assert.assertNotNull(countries);
+  		Assert.assertEquals(countries.size(), result.size());
+  		List<String> countryNames = new ArrayList<>();
+  		for(int i=0; i<countries.size(); i++) {
+  			countryNames.add(countries.get(i).getName());
+  			System.out.println(countryNames.get(i));
+  		}
+  		Assert.assertTrue(result.equals(countryNames));
+  	}
 
     @Test
     public void getByNamePriority() throws Exception {


### PR DESCRIPTION
Fixes #55 
Searches by partial name matches results in a list of countries sorted by the relevance of the country to the search term. Different relevance values are assigned to countries based on whether the search term:
- Completely matches the country's name
- Completely matches one of the country's alternative spellings
- Matches a proper substring of the country's name
- Matches a proper substring of one of the country's alternative spellings.
Countries with equal relevance continue to appear in the order the are stored in the json file.